### PR TITLE
Fix urls

### DIFF
--- a/tools/champ_blocs/.shed.yml
+++ b/tools/champ_blocs/.shed.yml
@@ -1,7 +1,8 @@
 categories:
     - Ecology
 owner: ecology
-remote_repository_url: https://github.com/Marie59/champ_blocs
+homepage_url: https://github.com/Marie59/champ_blocs
+remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/champ_blocs
 long_description: |
   Compute indicators for turnover boulders fields
 type: unrestricted

--- a/tools/data_exploration/.shed.yml
+++ b/tools/data_exploration/.shed.yml
@@ -1,7 +1,8 @@
 categories:
     - Ecology
 owner: ecology
-remote_repository_url: https://github.com/Marie59/Data_explo_tools
+homepage_url: https://github.com/Marie59/Data_explo_tools
+remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/data_exploration
 long_description: |
   Explore data through multiple statistical tools
 type: unrestricted

--- a/tools/hirondelle_crim_ogc_api_processes/.shed.yml
+++ b/tools/hirondelle_crim_ogc_api_processes/.shed.yml
@@ -1,7 +1,7 @@
 categories:
     - Ecology
 owner: ecology
-remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/ogc_api_processes_wrapper
+remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/hirondelle_crim_ogc_api_processes
 homepage_url: https://github.com/AquaINFRA/galaxy
 long_description: |
   This tool is a wrapper for OGC API Processes coming from https://osf.io/gfbws/.

--- a/tools/ogcProcess_otb_bandmath/.shed.yml
+++ b/tools/ogcProcess_otb_bandmath/.shed.yml
@@ -1,7 +1,7 @@
 categories:
     - Ecology
 owner: ecology
-remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/OtbBandMath
+remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/ogcProcess_otb_bandmath
 homepage_url: https://github.com/AquaINFRA/galaxy
 long_description: |
   Outputs a monoband image which is the result of a mathematical operation on several multi-band images.

--- a/tools/ogcProcess_otb_meanShiftSmoothing/.shed.yml
+++ b/tools/ogcProcess_otb_meanShiftSmoothing/.shed.yml
@@ -1,7 +1,7 @@
 categories:
     - Ecology
 owner: ecology
-remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/interpolation
+remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/ogcProcess_otb_meanShiftSmoothing
 homepage_url: https://github.com/AquaINFRA/galaxy
 long_description: |
   This application smooths an image using the MeanShift algorithm.

--- a/tools/srs_tools/.shed.yml
+++ b/tools/srs_tools/.shed.yml
@@ -1,7 +1,8 @@
 categories:
     - Ecology
 owner: ecology
-remote_repository_url: https://github.com/Marie59/Sentinel_2A/srs_tools
+homepage_url: https://github.com/Marie59/Sentinel_2A/srs_tools
+remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/srs_tools
 long_description: |
   Compute biodiversity indicators for remote sensing data from Sentinel 2
 type: unrestricted

--- a/tools/zoo_project_ogc_api_processes/.shed.yml
+++ b/tools/zoo_project_ogc_api_processes/.shed.yml
@@ -1,7 +1,7 @@
 categories:
     - Ecology
 owner: ecology
-remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/ogc_api_processes_wrapper
+remote_repository_url: https://github.com/galaxyecology/tools-ecology/tree/master/tools/zoo_project_ogc_api_processes
 homepage_url: https://github.com/AquaINFRA/galaxy
 long_description: |
   This tool is a wrapper for OGC API Processes (OTB) coming from the Zoo Project (https://zoo-project.github.io/docs/intro.html) and was created using the OGC-API-Process2Galaxy tool (https://github.com/AquaINFRA/OGC-API-Process2Galaxy). Check the README in the repository for more information.


### PR DESCRIPTION
Fixing some bad urls in shed.yml (mine did a bit of a mess now it's better) and @MarkusKonk for the `remote_repository_url` be careful I think your putting some other folder in the link you need to put the same than where is the .shed.yml file of your tool in the ecology github repo 