### PR TITLE
Update pr workflow to use pull_request_target

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,6 +1,6 @@
 name: Galaxy Tool Linting and Tests for push and PR
 on:
-  pull_request:
+  pull_request_target:
     paths-ignore:
       - '.github/**'
       - 'deprecated/**'


### PR DESCRIPTION
Switching from `pull_request` to `pull_request_target` to allow access to secrets during workflow runs.