### PR TITLE
send title information from the OneStop4All to Galaxy

### DIFF
--- a/tools/nfdi4earth_os4a_importer/nfdi4earth_os4a_importer.xml
+++ b/tools/nfdi4earth_os4a_importer/nfdi4earth_os4a_importer.xml
@@ -1,4 +1,4 @@
-<tool id="nfdi4earth_os4a" name="NFDI4Earth OneStop4All Importer" tool_type="data_source" version="1.0" profile="20.09">
+<tool id="nfdi4earth_os4a" name="NFDI4Earth OneStop4All Importer" tool_type="data_source" version="1.1" profile="20.09">
     <description>downloads content via NFDI4Earth's OS4A search user interface</description>
     <command><![CDATA[
         python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit


### PR DESCRIPTION
The datasets in the OneStop4All have a title in the metadata, which should be sent to Galaxy to give the data in the history a proper name. 

Btw: The implementation in the OneStop4All ("Import to Galaxy"-button) is not yet online but we're pretty far already. See screenshot below of the current state running locally.

<img width="1547" height="679" alt="image" src="https://github.com/user-attachments/assets/b93b5ec9-024b-452e-9d7c-52b2237aaf3c" />
