### PR TITLE
Sam3: new help, new parameter (imgsz)

### DIFF
--- a/tools/Sam3/sam3_semantic_segmentation.py
+++ b/tools/Sam3/sam3_semantic_segmentation.py
@@ -587,7 +587,7 @@ def main():
         "task": "segment",
         "mode": "predict",
         "model": args.model,
-        "half": True,
+        "half": False,
         "imgsz": args.imgsz,
         "save": True,
         "save_dir": str(outputs_annotated),

--- a/tools/Sam3/sam3_semantic_segmentation.py
+++ b/tools/Sam3/sam3_semantic_segmentation.py
@@ -87,6 +87,12 @@ def parse_arguments() -> argparse.Namespace:
         help="Show bounding boxes on annotated output: 'true' or 'false'",
     )
     parser.add_argument(
+        "--imgsz",
+        type=int,
+        default=1024,
+        help="Inference image size (pixels). Reduce to 640 or 512 to lower GPU memory usage on large files.",
+    )
+    parser.add_argument(
         "--coco_video_mode",
         type=str,
         default="no_coco",
@@ -580,7 +586,8 @@ def main():
         "task": "segment",
         "mode": "predict",
         "model": args.model,
-        "half": False,  # Use FP16 for faster inference
+        "half": True,
+        "imgsz": args.imgsz,
         "save": True,
         "save_dir": str(outputs_annotated),
     }

--- a/tools/Sam3/sam3_semantic_segmentation.py
+++ b/tools/Sam3/sam3_semantic_segmentation.py
@@ -90,7 +90,8 @@ def parse_arguments() -> argparse.Namespace:
         "--imgsz",
         type=int,
         default=1024,
-        help="Inference image size (pixels). Reduce to 640 or 512 to lower GPU memory usage on large files.",
+        help="Inference image size (pixels). Reduce to 640 or 512 to "
+        " lower GPU memory usage on large files.",
     )
     parser.add_argument(
         "--coco_video_mode",

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -1,4 +1,4 @@
-<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy5" profile="25.1">
+<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy4" profile="25.1">
     <description>
         SAM3 performs text-prompted semantic segmentation on images or videos. 
     </description>
@@ -13,11 +13,11 @@
     #set $name_file = '' 
     #if $input.input_kind == "image"
         #for $indata in $input.source
-            ln -s '$indata' 'data_files/${indata.element_identifier}' &&
+            ln -s '$indata' 'data_files/${indata.element_identifier}.${indata.ext}' &&
             #set $name_file += $indata.element_identifier + " "
         #end for
     #else
-        ln -s '$input.source' 'data_files/${input.source.element_identifier}' &&
+        ln -s '$input.source' 'data_files/${input.source.element_identifier}.${indata.ext}' &&
         #set $name_file = $input.source.element_identifier + " "
     #end if
     python '$__tool_directory__/sam3_semantic_segmentation.py' 
@@ -60,7 +60,6 @@
             </param>
             <when value="image">
                 <param name="source" type="data" format="jpg,png,tiff" multiple="true" label="Input images">
-                    <validator type="expression" message="Your image file must have a valid extension (e.g. rename 'image' to 'image.png'). Supported formats: .jpg, .png, .tif">value.name.lower().endswith(('.jpg', '.jpeg', '.png', '.tiff', '.tif'))</validator>
                     <validator type="expression" message="TIFF images must contain exactly 3 channels (RGB).">value.ext not in ('tiff') or value.metadata.channels == 3</validator>
                 </param>
                 <param name="outputs_format" type="select" multiple="true" optional="true"
@@ -73,9 +72,7 @@
             </when>
             <when value="video">
                 <param name="source" type="data" format="mp4,avi,mov,gif"
-                    multiple="false" label="Input video file">
-                    <validator type="expression" message="Your video file must have a valid extension (e.g. rename 'video' to 'video.mp4'). Supported formats: .mp4, .avi, .mov, .gif">value.name.lower().endswith(('.mp4', '.avi', '.mov', '.gif'))</validator>
-                </param>
+                    multiple="false" label="Input video file"/>
                 <param name="quality" type="select" label="Video quality"
                     help="Select output video bitrate,does not affect processing speed or annotations. 
                           Higher quality than the original is not useful and will only increase file size.">
@@ -207,14 +204,7 @@ Input
 - **Images**: .jpg, .png, .tiff — multiple files accepted 
 - **Video**: .mp4, .avi, .mov, .gif — single file only
 
-.. class:: infomark 
-
-Pay attention to file extensions
-
-- **Galaxy has assigned the wrong datatype**: your file does not appear in the tool input list, click the pencil icon in the history, go to the **Datatype** tab, select the correct format and click **Save**.
-- **The file name has no extension**: the Run button is not active, make sure your file name ends with a valid extension (e.g. rename image to image.jpg) by clicking the pencil icon in the history and fixing it in the **Name** field.
-
-
+.. note:: The datatype assigned by Galaxy may not be compatible with this tool: if your file does **not appear** in the tool input list, click the **pencil icon** in the history, go to the **Datatype** tab, select the correct format and click Save.
 -------------------
 Notes
 -------------------

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -1,4 +1,4 @@
-<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.2+galaxy5" profile="25.1">
+<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy5" profile="25.1">
     <description>
         SAM3 performs text-prompted semantic segmentation on images or videos. 
     </description>

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -1,4 +1,4 @@
-<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy4" profile="25.1">
+<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy5" profile="25.1">
     <description>
         SAM3 performs text-prompted semantic segmentation on images or videos. 
     </description>

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -205,6 +205,7 @@ Input
 - **Video**: .mp4, .avi, .mov, .gif — single file only
 
 .. note:: The datatype assigned by Galaxy may not be compatible with this tool: if your file does **not appear** in the tool input list, click the **pencil icon** in the history, go to the **Datatype** tab, select the correct format and click Save.
+
 -------------------
 Notes
 -------------------

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -42,6 +42,7 @@
         #end if
         --do_normalization '$do_normalization'
         --show_bbox '$show_bbox'
+        --imgsz '$imgsz'
     ]]></command>
     <inputs>
         <param name="sam3_models" label="Model data" type="select" help="Contact the administrator of our Galaxy instance if you miss model data">
@@ -115,6 +116,16 @@
             help="For video input: process one frame every N frames."/>
         <param name="show_bbox" type="boolean" checked="true" truevalue="true" falsevalue="false"
             label="Show bounding boxes on annotated output"/>
+        <param name="imgsz" type="select" label="Inference image size"
+            help="Resolution at which the image is resized before segmentation.
+                A higher value preserves more detail and improves boundary accuracy,
+                especially for small objects, but increases computation time and GPU memory usage.
+                If you encounter out-of-memory errors, select a lower value.">
+            <option value="1280">1280 (highest accuracy)</option>
+            <option value="1024">1024 (high accuracy)</option>
+            <option value="640" selected="true">640 (default, balanced)</option>
+            <option value="512">512 (low memory)</option>
+        </param>
         <param name="do_normalization" type="boolean" checked="false" label="Normalize outputs?" >
             <help><![CDATA[
 This option will be applied to all selected formats above.<br/>

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -1,4 +1,4 @@
-<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy4" profile="25.1">
+<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.2+galaxy5" profile="25.1">
     <description>
         SAM3 performs text-prompted semantic segmentation on images or videos. 
     </description>

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -59,6 +59,7 @@
             </param>
             <when value="image">
                 <param name="source" type="data" format="jpg,png,tiff" multiple="true" label="Input images">
+                    <validator type="expression" message="Your image file must have a valid extension (e.g. rename 'image' to 'image.png'). Supported formats: .jpg, .png, .tif">value.name.lower().endswith(('.jpg', '.jpeg', '.png', '.tiff', '.tif'))</validator>
                     <validator type="expression" message="TIFF images must contain exactly 3 channels (RGB).">value.ext not in ('tiff') or value.metadata.channels == 3</validator>
                 </param>
                 <param name="outputs_format" type="select" multiple="true" optional="true"
@@ -71,7 +72,9 @@
             </when>
             <when value="video">
                 <param name="source" type="data" format="mp4,avi,mov,gif"
-                    multiple="false" label="Input video file"/>
+                    multiple="false" label="Input video file">
+                    <validator type="expression" message="Your video file must have a valid extension (e.g. rename 'video' to 'video.mp4'). Supported formats: .mp4, .avi, .mov, .gif">value.name.lower().endswith(('.mp4', '.avi', '.mov', '.gif'))</validator>
+                </param>
                 <param name="quality" type="select" label="Video quality"
                     help="Select output video bitrate,does not affect processing speed or annotations. 
                           Higher quality than the original is not useful and will only increase file size.">
@@ -185,6 +188,21 @@ How it works
 2. Enter a text prompt describing the object to segment
 3. SAM3 generates segmentation masks and overlays
 4. Results are returned as images or videos
+
+-------------------
+Input
+-------------------
+
+- **Images**: .jpg, .png, .tiff — multiple files accepted 
+- **Video**: .mp4, .avi, .mov, .gif — single file only
+
+.. class:: infomark 
+
+Pay attention to file extensions
+
+- **Galaxy has assigned the wrong datatype**: your file does not appear in the tool input list, click the pencil icon in the history, go to the **Datatype** tab, select the correct format and click **Save**.
+- **The file name has no extension**: the Run button is not active, make sure your file name ends with a valid extension (e.g. rename image to image.jpg) by clicking the pencil icon in the history and fixing it in the **Name** field.
+
 
 -------------------
 Notes


### PR DESCRIPTION
Add imgsz parameter (supported inference image sizes: 512, 640, 1024, 1280) passed to the SAM3 predictor to reduce out-of-memory issues during inference
Add validators for image and video input extensions
Add in Help section with troubleshooting guidance for missing or invalid file extensions