### PR TITLE
Sam3 fix error video

### DIFF
--- a/tools/Sam3/sam3_semantic_segmentation.py
+++ b/tools/Sam3/sam3_semantic_segmentation.py
@@ -124,7 +124,7 @@ def convert_avi_to_mp4(directory_path, quality):
     print(f"Converting: {avi_file_path} -> {output_path}.mp4")
     audio_args = "-an"  # remove audio
     if quality == "copy":
-        video_args = "-c:v libx264 -crf 18 -preset slow -profile:v high" 
+        video_args = "-c:v libx264 -crf 18 -preset slow -profile:v high"
     else:
         video_args = (
             f"-c:v libx264 -b:v {quality} "

--- a/tools/Sam3/sam3_semantic_segmentation.py
+++ b/tools/Sam3/sam3_semantic_segmentation.py
@@ -89,8 +89,8 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--imgsz",
         type=int,
-        default=1024,
-        help="Inference image size (pixels). Reduce to 640 or 512 to "
+        default=1036,
+        help="Inference image size (pixels). Reduce to 644 or 518 to "
         " lower GPU memory usage on large files.",
     )
     parser.add_argument(

--- a/tools/Sam3/sam3_semantic_segmentation.py
+++ b/tools/Sam3/sam3_semantic_segmentation.py
@@ -124,7 +124,7 @@ def convert_avi_to_mp4(directory_path, quality):
     print(f"Converting: {avi_file_path} -> {output_path}.mp4")
     audio_args = "-an"  # remove audio
     if quality == "copy":
-        video_args = "-c:v copy"  # copy video stream without re-encoding
+        video_args = "-c:v libx264 -crf 18 -preset slow -profile:v high" 
     else:
         video_args = (
             f"-c:v libx264 -b:v {quality} "

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -1,4 +1,4 @@
-<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy4" profile="25.1">
+<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy5" profile="25.1">
     <description>
         SAM3 performs text-prompted semantic segmentation on images or videos. 
     </description>

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -1,4 +1,4 @@
-<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy5" profile="25.1">
+<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy4" profile="25.1">
     <description>
         SAM3 performs text-prompted semantic segmentation on images or videos. 
     </description>
@@ -17,7 +17,7 @@
             #set $name_file += $indata.element_identifier + " "
         #end for
     #else
-        ln -s '$input.source' 'data_files/${input.source.element_identifier}.${indata.ext}' &&
+        ln -s '$input.source' 'data_files/${input.source.element_identifier}.${input.source.ext}' &&
         #set $name_file = $input.source.element_identifier + " "
     #end if
     python '$__tool_directory__/sam3_semantic_segmentation.py' 
@@ -118,10 +118,10 @@
                 A higher value preserves more detail and improves boundary accuracy,
                 especially for small objects, but increases computation time and GPU memory usage.
                 If you encounter out-of-memory errors, select a lower value.">
-            <option value="1280">1280 (highest accuracy)</option>
-            <option value="1024">1024 (high accuracy)</option>
-            <option value="640" selected="true">640 (default, balanced)</option>
-            <option value="512">512 (low memory)</option>
+            <option value="1288">1288 (highest accuracy)</option>
+            <option value="1036">1036 (high accuracy)</option>
+            <option value="644" selected="true">644 (default, balanced)</option>
+            <option value="518">518 (low memory)</option>
         </param>
         <param name="do_normalization" type="boolean" checked="false" label="Normalize outputs?" >
             <help><![CDATA[


### PR DESCRIPTION
Hi @bgruening 
I made a mistake on this line. Could you push this fixed version directly? SAM3 video mode is currently broken, at least for version 5.
`        ln -s '$input.source' 'data_files/${input.source.element_identifier}.${input.source.ext}' &&`
