### PR TITLE
Sam3 add new option and fix frame_idx

### DIFF
--- a/tools/Sam3/sam3_semantic_segmentation.py
+++ b/tools/Sam3/sam3_semantic_segmentation.py
@@ -686,7 +686,10 @@ def main():
         convert_avi_to_mp4(outputs_annotated, args.quality)
 
         if args.output_frames != "none":
-            print(f"\n→ Extracting video frames (mode: {args.output_frames})...")
+            print(
+                f"\n→ Extracting video frames "
+                f"(mode: {args.output_frames})..."
+            )
             raw_dir = (
                 outdir / "frames_raw"
                 if args.output_frames in ("raw", "both")

--- a/tools/Sam3/sam3_semantic_segmentation.py
+++ b/tools/Sam3/sam3_semantic_segmentation.py
@@ -96,12 +96,19 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument(
         "--coco_video_mode",
         type=str,
-        default="no_coco",
-        choices=["video", "frames", "no_coco"],
-        help="For video input with COCO output: 'video' annotates the video"
-        "as a single source, 'frames' extracts each processed frame as an "
-        "individual image and annotates per frame, 'no_coco' disables "
-        "COCO output",
+        default="video",
+        choices=["video"],
+        help="just video",
+    )
+    parser.add_argument(
+        "--output_frames",
+        type=str,
+        default="none",
+        choices=["none", "annotated", "raw", "both"],
+        help="For video input: extract individual frames as images. "
+        "'annotated' saves frames with segmentation overlays, "
+        "'raw' saves original frames without annotations, "
+        "'both' saves both versions.",
     )
     return parser.parse_args()
 
@@ -519,6 +526,59 @@ def create_yolo_video_output(
     print(f"✓ Created {saved_idx} frames and labels in {output_dir}")
 
 
+def extract_video_frames(
+    video_path: str,
+    stride: int,
+    results: List[Any],
+    raw_dir: Path = None,
+    annotated_dir: Path = None,
+    show_bbox: bool = True,
+) -> None:
+    """Extract video frames as images, annotated and/or raw."""
+    if raw_dir:
+        raw_dir.mkdir(parents=True, exist_ok=True)
+    if annotated_dir:
+        annotated_dir.mkdir(parents=True, exist_ok=True)
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise RuntimeError(f"Failed to open video: {video_path}")
+
+    video_name = Path(video_path).stem
+    frame_idx = 1 if stride > 1 else 0
+    saved_idx = 0
+
+    print(f"Extracting frames (stride={stride})...")
+
+    while cap.isOpened():
+        ret, frame = cap.read()
+        if not ret:
+            break
+
+        if frame_idx % stride == 0:
+            if saved_idx >= len(results):
+                print(f"Warning: No result available for frame {frame_idx}")
+                break
+
+            frame_name = f"{video_name}_frame_{frame_idx:06d}.jpg"
+
+            if raw_dir is not None:
+                cv2.imwrite(str(raw_dir / frame_name), frame)
+
+            if annotated_dir is not None:
+                annotated_frame = results[saved_idx].plot(boxes=show_bbox)
+                cv2.imwrite(str(annotated_dir / frame_name), annotated_frame)
+
+            saved_idx += 1
+            if saved_idx % 10 == 0:
+                print(f"  Extracted {saved_idx} frames...")
+
+        frame_idx += 1
+
+    cap.release()
+    print(f"✓ Extracted {saved_idx} frames")
+
+
 def create_metadata(
     text_prompts: List[str], conf_threshold: float, model_path: str
 ) -> Dict[str, Any]:
@@ -625,6 +685,27 @@ def main():
     if is_video(file_paths[0]):
         convert_avi_to_mp4(outputs_annotated, args.quality)
 
+        if args.output_frames != "none":
+            print(f"\n→ Extracting video frames (mode: {args.output_frames})...")
+            raw_dir = (
+                outdir / "frames_raw"
+                if args.output_frames in ("raw", "both")
+                else None
+            )
+            annotated_dir = (
+                outdir / "frames_annotated"
+                if args.output_frames in ("annotated", "both")
+                else None
+            )
+            extract_video_frames(
+                file_paths[0],
+                args.vid_stride,
+                results,
+                raw_dir=raw_dir,
+                annotated_dir=annotated_dir,
+                show_bbox=show_bbox,
+            )
+
     if not results:
         raise RuntimeError("SAM3 returned no results")
 
@@ -641,7 +722,7 @@ def main():
     if "coco" in output_formats:
         print("\n→ Converting to COCO format...")
 
-        if is_video(file_paths[0]) and args.coco_video_mode == "frames":
+        if is_video(file_paths[0]) and args.coco_video_mode == "video":
             print("  Mode: per-frame (extracting individual frames)...")
             coco_output = create_coco_video_frames_output(
                 results,

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -1,4 +1,4 @@
-<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy5" profile="25.1">
+<tool id="sam3_semantic_segmentation" name="SAM3 Semantic Segmentation" version="1.0.1+galaxy6" profile="25.1">
     <description>
         SAM3 performs text-prompted semantic segmentation on images or videos. 
     </description>
@@ -160,6 +160,21 @@ This option will be applied to all selected formats above.<br/>
             <discover_datasets pattern="__name_and_ext__" directory="outputs/yolo_seg/labels"/>
         </collection>
     </outputs>
+    <tests>
+        <test expect_exit_code="1" expect_failure="true">
+            <param name="sam3_models" value="unknown"/>
+            <conditional name="input">
+                <param name="input_kind" value="image" />
+                <param name="source" value="5827603936_3f1d5d715c_z.jpg,shrimp.png"/>
+                <param name="outputs_format" value="coco,yolo_bbox"/>
+            </conditional>
+            <param name="text_prompt" value="elephant"/>
+            <param name="conf" value="0.25"/>
+            <assert_stdout>
+                <has_text text="Invalid model!"/>
+            </assert_stdout>
+        </test>
+    </tests>
     <help><![CDATA[
 
 ===================================================

--- a/tools/Sam3/sam3_semantic_segmentation.xml
+++ b/tools/Sam3/sam3_semantic_segmentation.xml
@@ -29,16 +29,12 @@
         --name_file '$name_file'
         #if $input.input_kind == "video"
             --quality '$input.quality'
+            --output_frames '$input.output_frames'
         #end if
         #if $input.input_kind == "image"
             --outputs $input.outputs_format
         #else
-            #if $input.coco_video_mode != "no_coco"
-                --outputs 'coco, $input.outputs_format'
-                --coco_video_mode '$input.coco_video_mode'
-            #else
-                --outputs $input.outputs_format
-            #end if
+            --outputs 'coco,$input.outputs_format'
         #end if
         --do_normalization '$do_normalization'
         --show_bbox '$show_bbox'
@@ -82,18 +78,18 @@
                     <option value="4000k">4000k - Good (1080p)</option>
                     <option value="8000k">8000k - High quality (1080p)</option>
                 </param>
-                <param name="coco_video_mode" type="select"
-                    label="COCO output mode"
-                    help="Controls whether COCO annotations are generated, and how frames are referenced.">
-                    <option value="video" selected="true">Annotate the video — one COCO entry per frame, referencing the video file</option>
-                    <option value="frames">Annotate extracted frames — saves JPGs and one COCO entry per frame image</option>
-                    <option value="no_coco">No COCO output</option>
-                </param>
                 <param name="outputs_format" type="select" multiple="true" optional="true"
                     label="Additional output formats"
                     help="YOLO formats are optional. COCO output is controlled separately above.">
                     <option value="yolo_bbox">YOLO bounding boxes</option>
                     <option value="yolo_seg">YOLO segmentation masks</option>
+                </param>
+                <param name="output_frames" type="select" label="Export individual frames"
+                    help="Extract individual frames from the video as images (at the chosen frame stride).">
+                    <option value="none" selected="true">None</option>
+                    <option value="annotated">Annotated frames only (with segmentation overlay)</option>
+                    <option value="raw">Raw frames only (no annotations)</option>
+                    <option value="both">Both annotated and raw frames</option>
                 </param>
             </when>
         </conditional>
@@ -134,14 +130,18 @@ This option will be applied to all selected formats above.<br/>
     </inputs>
     <outputs>
         <data name="Annotations_coco" format="json" from_work_dir="./outputs/annotations.json" label="Annotation COCO">
-            <filter>input['outputs_format'] and 'coco' in input['outputs_format'] or input.get('coco_video_mode') == "video" or input.get('coco_video_mode') == "frames"</filter>
+            <filter>input['input_kind'] == "video" or (input['outputs_format'] and 'coco' in input['outputs_format'])</filter>
         </data>
-        <collection name="Coco_Frames" type="list" label="COCO Extracted Frames">
-            <filter>input['input_kind'] == "video" and input.get('coco_video_mode') == "frames"</filter>
-            <discover_datasets pattern="__name_and_ext__" directory="outputs/frames"/>
-        </collection>
         <collection name="Outputs_annotated" type="list" label="Annotated Outputs">
             <discover_datasets pattern="__name_and_ext__" directory="outputs/outputs_annotated"/>
+        </collection>
+        <collection name="Raw_Frames" type="list" label="Raw Frames">
+            <filter>input['input_kind'] == "video" and input.get('output_frames') in ('raw', 'both')</filter>
+            <discover_datasets pattern="__name_and_ext__" directory="outputs/frames_raw"/>
+        </collection>
+        <collection name="Annotated_Frames" type="list" label="Annotated Frames">
+            <filter>input['input_kind'] == "video" and input.get('output_frames') in ('annotated', 'both')</filter>
+            <discover_datasets pattern="__name_and_ext__" directory="outputs/frames_annotated"/>
         </collection>
         <collection name="Yolo_Bbox_Image" type="list" label="YOLO Bbox Images">
             <filter>input['outputs_format'] and 'yolo_bbox' in input['outputs_format']</filter>
@@ -160,21 +160,6 @@ This option will be applied to all selected formats above.<br/>
             <discover_datasets pattern="__name_and_ext__" directory="outputs/yolo_seg/labels"/>
         </collection>
     </outputs>
-    <tests>
-        <test expect_exit_code="1" expect_failure="true">
-            <param name="sam3_models" value="unknown"/>
-            <conditional name="input">
-                <param name="input_kind" value="image" />
-                <param name="source" value="5827603936_3f1d5d715c_z.jpg,shrimp.png"/>
-                <param name="outputs_format" value="coco,yolo_bbox"/>
-            </conditional>
-            <param name="text_prompt" value="elephant"/>
-            <param name="conf" value="0.25"/>
-            <assert_stdout>
-                <has_text text="Invalid model!"/>
-            </assert_stdout>
-        </test>
-    </tests>
     <help><![CDATA[
 
 ===================================================


### PR DESCRIPTION
- Add `output_frames` option for video input: export individual frames  as annotated (with segmentation overlay), raw, or both
- COCO annotations are now always generated for video input, the  `coco_video_mode` user parameter has been removed (+ fix problem frame_idx)